### PR TITLE
set correct context when call expose

### DIFF
--- a/__tests__/expose.test.js
+++ b/__tests__/expose.test.js
@@ -2,18 +2,23 @@ import Vue from 'vue';
 import { expose } from '../src';
 
 describe('expose', () => {
-
     it('can expose any value', () => {
         const vm = new Vue({
             mixins: [expose],
+            data() {
+                return {
+                    myOtherProp: 'bar',
+                };
+            },
             expose() {
                 return {
                     myProp: 'foo',
+                    myOtherProp: this.myOtherProp,
                 };
             },
         });
 
-        expect(vm.$exposed).toEqual({ myProp: 'foo' });
+        expect(vm.$exposed).toEqual({ myProp: 'foo', myOtherProp: 'bar' });
     });
 
     it('can expose an array of named properties', () => {

--- a/__tests__/expose.test.js
+++ b/__tests__/expose.test.js
@@ -1,6 +1,10 @@
 import Vue from 'vue';
 import { expose } from '../src';
 
+Vue.config.errorHandler = (err, vm, info) => {
+    vm._error = err;
+};
+
 describe('expose', () => {
     it('can expose any value', () => {
         const vm = new Vue({
@@ -36,11 +40,11 @@ describe('expose', () => {
     });
 
     it('throws an error if a property that doesn\'t exist gets exposed', () => {
-        expect(() => {
-            new Vue({
-                mixins: [expose],
-                expose: ['myProp'],
-            });
-        }).toThrow();
+        const vm = new Vue({
+            mixins: [expose],
+            expose: ['myProp'],
+        });
+
+        expect(vm._error).toBeDefined();
     });
 });

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "babel-cli": "^6.9.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-preset-es2015": "^6.9.0",
-    "eslint": "^3.7.1",
-    "eslint-config-spatie": "^1.1.0",
-    "jest": "^17.0.2",
+    "eslint": "^4.19.1",
+    "eslint-config-spatie": "^2.0.3",
+    "jest": "^22.4.3",
     "vue": "^2.0.0"
   },
   "peerDependencies": {

--- a/src/expose.js
+++ b/src/expose.js
@@ -2,11 +2,11 @@ import { isArray, isFunction } from './util';
 
 function retrieveExposedProperties(vm) {
     const expose = vm.$options.expose;
-    
+
     if (isFunction(expose)) {
-        return expose();
+        return expose.call(vm);
     }
-    
+
     if (isArray(expose)) {
         return expose.reduce((expose, property) => {
             if (! vm.hasOwnProperty(property)) {
@@ -27,7 +27,7 @@ const expose = {
         if (this.$options.expose === undefined) {
             return;
         }
-        
+
         this.$exposed = retrieveExposedProperties(this);
     },
 };


### PR DESCRIPTION
At the moment you cannot use the following example because you cannot access to the instance.

[Sandbox](https://codesandbox.io/s/0j8734x0p)

```js
// Expose a property...
const vm = new Vue({
    mixins: [expose],

    data: () => ({
        bus: new Bus(),
    }),

    expose() {
        return {
            bus: this.bus,
        };
    },
});
```